### PR TITLE
Adds incrementer data generator and migrates to raintank

### DIFF
--- a/agents/agent.go
+++ b/agents/agent.go
@@ -3,9 +3,9 @@ package agents
 import (
 	"time"
 
-	"github.com/OOM-Killer/fakemetrics_ng/datagen"
-	"github.com/OOM-Killer/fakemetrics_ng/out"
-	"github.com/OOM-Killer/fakemetrics_ng/timer"
+	"github.com/raintank/fakemetrics_ng/datagen"
+	"github.com/raintank/fakemetrics_ng/out"
+	"github.com/raintank/fakemetrics_ng/timer"
 )
 
 type Agent struct {

--- a/agents/agents.go
+++ b/agents/agents.go
@@ -5,9 +5,9 @@ import (
 	"math/rand"
 	"time"
 
-	"github.com/OOM-Killer/fakemetrics_ng/datagen"
-	"github.com/OOM-Killer/fakemetrics_ng/out"
-	"github.com/OOM-Killer/fakemetrics_ng/timer"
+	"github.com/raintank/fakemetrics_ng/datagen"
+	"github.com/raintank/fakemetrics_ng/out"
+	"github.com/raintank/fakemetrics_ng/timer"
 )
 
 type Agents struct {

--- a/configuration.go
+++ b/configuration.go
@@ -6,10 +6,10 @@ import (
 
 	gc "github.com/rakyll/globalconf"
 
-	"github.com/OOM-Killer/fakemetrics_ng/agents"
-	"github.com/OOM-Killer/fakemetrics_ng/datagen"
-	"github.com/OOM-Killer/fakemetrics_ng/out"
-	"github.com/OOM-Killer/fakemetrics_ng/timer"
+	"github.com/raintank/fakemetrics_ng/agents"
+	"github.com/raintank/fakemetrics_ng/datagen"
+	"github.com/raintank/fakemetrics_ng/out"
+	"github.com/raintank/fakemetrics_ng/timer"
 )
 
 type stringListFlags []string

--- a/datagen/incrementer.go
+++ b/datagen/incrementer.go
@@ -1,0 +1,60 @@
+package datagen
+
+import (
+	"flag"
+	"fmt"
+	gc "github.com/rakyll/globalconf"
+	"gopkg.in/raintank/schema.v1"
+)
+
+type Incrementer struct {
+	id       int
+	maxValue float64
+	minValue float64
+	curValue float64
+	metName  string
+}
+
+var (
+	maxValue     float64
+	minValue     float64
+	incKeyPrefix string
+)
+
+func init() {
+	modules["incrementer"] = incNew
+	regFlags = append(regFlags, incRegFlags)
+}
+
+func incNew(id int) Datagen {
+	return &Incrementer{id, maxValue, minValue, 0, fmt.Sprintf(incKeyPrefix+"%d", id)}
+}
+
+func incRegFlags() {
+	flags := flag.NewFlagSet("incrementer", flag.ExitOnError)
+	flags.Float64Var(&maxValue, "max-value", 100, "integer at which we reset to 0")
+	flags.Float64Var(&minValue, "min-value", 0, "integer at which we start")
+	flags.StringVar(&incKeyPrefix, "key-prefix", "fake.incrementer", "prefix for keys")
+	gc.Register("incrementer", flags)
+}
+
+func (i *Incrementer) GetData(ts int64) []*schema.MetricData {
+	metrics := make([]*schema.MetricData, 1)
+	metrics[0] = &schema.MetricData{
+		Name:   i.metName,
+		Metric: i.metName,
+		OrgId:  1,
+		Value:  i.curValue,
+		Unit:   "ms",
+		Mtype:  "gauge",
+		Tags:   []string{},
+		Time:   ts,
+	}
+
+	i.curValue++
+	if i.curValue >= i.maxValue {
+		i.curValue = i.minValue
+	}
+
+	return metrics
+}

--- a/fakemetrics.go
+++ b/fakemetrics.go
@@ -3,7 +3,7 @@ package main
 import (
 	"flag"
 
-	"github.com/OOM-Killer/fakemetrics_ng/agents"
+	"github.com/raintank/fakemetrics_ng/agents"
 )
 
 var (

--- a/fakemetrics.ini
+++ b/fakemetrics.ini
@@ -1,10 +1,10 @@
 
 [modules]
 # timers: realtime, backfill, flexible
-timer = flexible
+timer = realtime
 
-# data generators: simple, keychanger
-data-gen = keychanger
+# data generators: simple, keychanger, incrementer
+data-gen = incrementer
 
 # outputs: carbon
 output = carbon
@@ -38,7 +38,7 @@ min-interval = 100
 
 # if true each agent will get a random interval within the configured range
 # if false the agent intervals will be evenly spread through the range
-random-distribution = true
+random-distribution = false
 
 
 ### DATA GENERATORS ###
@@ -68,6 +68,18 @@ key-prefix = a.test2.
 # otherwise the changing is distributed over intervals
 sync-switch = false
 
+# incrementer is a data generator where each metric just increments by one
+# to the max and then wraps around to the min
+[incrementer]
+
+# the value at which each agent starts
+min-value = 0
+
+# the value at which each agent wraps around to the min-value
+max-value = 100
+
+# prefix before each key
+key-prefix = fake.incrementer
 
 ### OUTPUTS ###
 
@@ -94,16 +106,16 @@ block-on-write = true
 [multiagent]
 
 # number of agents to create
-agent-count = 3
+agent-count = 10
 
 # configures a time offset in the creation of agents
 # none: no offset
 # even: evenly spread the offsets over the time span of one metric interval
 # random: use random offsets between 0 and one metric interval
-offsets = random
+offsets = none
 
 # increase the count of agents slowly instead of creating all at once
 slow-increase = true
 
 # interval of launching new agents when slow-increase is on
-launch-interval = 1000
+launch-interval = 3000


### PR DESCRIPTION
- migrates all the include paths to the raintank github user
- adds a datagenerator which continously increases the metric value
  until a max is reached, at which point it wraps around to the min

closes https://github.com/raintank/fakemetrics_ng/issues/1

![screenshot from 2016-12-27 13-31-18](https://cloud.githubusercontent.com/assets/195371/21500684/4dc91e00-cc39-11e6-86e6-36ef81c9b473.png)